### PR TITLE
 Accept sysex strings in ascii hexadecimal notation with no white-space separation

### DIFF
--- a/mididings/util.py
+++ b/mididings/util.py
@@ -293,7 +293,11 @@ def subscene_number(subscene):
 def sysex_to_bytearray(sysex):
     if isinstance(sysex, str):
         if sysex.startswith('F0') or sysex.startswith('f0'):
-            return bytearray(int(x, 16) for x in sysex.split(sysex[2]))
+            if len(sysex) < 3 or sysex[2] not in ', \f\n\r\t\v':
+                return bytearray(int(sysex[i:i+2], 16)
+                                 for i in range(0, len(sysex), 2))
+            else:
+                return bytearray(int(x, 16) for x in sysex.split(sysex[2]))
         else:
             return bytearray(map(ord, sysex))
     elif isinstance(sysex, bytearray):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -114,9 +114,17 @@ class UtilTestCase(MididingsTestCase):
             sysex_data('f0,04,08,15,16,23,42,f7'),
             self.native_sysex('\xf0\x04\x08\x15\x16\x23\x42\xf7'))
         self.assertEqual(
+            sysex_data('F0040815162342F7'),
+            self.native_sysex('\xf0\x04\x08\x15\x16\x23\x42\xf7'))
+        self.assertEqual(
+            sysex_data('f0040815162342f7'),
+            self.native_sysex('\xf0\x04\x08\x15\x16\x23\x42\xf7'))
+        self.assertEqual(
             sysex_data('\xf0\x23\x42\x66', allow_partial=True),
             self.native_sysex('\xf0\x23\x42\x66'))
 
+        with self.assertRaises(ValueError):
+            sysex_data('F0')
         with self.assertRaises(ValueError):
             sysex_data('\xf0')
         with self.assertRaises(ValueError):


### PR DESCRIPTION
... and comma/white space-separated single-digits bytes in `sysex_to_bytearray`.

Raise `ValueError` when both commas and white-space is used.

I.e. this is allowed:

```
sysex_data('F0040815162342F7')
sysex_data('f0040815162342f7')
sysex_data('f0 4 8 15162342f7')
sysex_data('f0,4,8,15,16,23,42,f7')
```

But not this:

```
sysex_data('f0,4,8 15162342f7')
```

The check in added line 288, searching for each white-space character, may be a bit excessive, esp. for long sysex strings, but the expression is ordered in such a way that the performance cost is only incurred when the sysex string contains a comma, which should be less common and even then it's still negligible, I think.

Instead, we could also only allow commas or spaces as separators:

```
    if sysex.startswith('F0') or sysex.startswith('f0'):
        if ',' in sysex and ' ' in sysex:
            raise ValueError("mixed comma and space chars in sysex string")
        result = bytearray()
        for group in sysex.split(',' if ',' in sysex else ' '):
            for hex in (group[i:i+2] for i in range(0, len(group), 2)):
                result.append(int(hex, 16))
        return result
```

(More than one consecutive space is handled by `range(0, len(group), 2)` yielding an empty sequence for empty string groups.)

But then other white-space characters may throw off the pair-wise conversion of hex chars to ints and produce hard to understand errors, e.g. this input:

```
sysex_data('f0,4,8\t\t15162342f7')
```
