### PR TITLE
Add support for get_client_name() and get_client_id() to engine

### DIFF
--- a/mididings/engine.py
+++ b/mididings/engine.py
@@ -358,6 +358,23 @@ def time():
     """
     return _TheEngine().time()
 
+def get_client_name():
+    """
+    Return actual client name
+    """
+    return _TheEngine().get_client_name()
+
+def get_client_id():
+    """
+    Return client id
+    """
+    if _setup.get_config('backend') == 'alsa':
+        return _TheEngine().get_client_id()
+    uuid = _TheEngine().get_client_uuid()
+    if uuid.isdigit():
+        return int(uuid)
+    return uuid
+
 def active():
     """
     Return ``True`` if the mididings engine is active (the :func:`~.run()`

--- a/src/backend/alsa.cc
+++ b/src/backend/alsa.cc
@@ -111,6 +111,26 @@ void ALSABackend::connect_ports(
 }
 
 
+std::string ALSABackend::get_actual_client_name()
+{
+    snd_seq_client_info_t *client_info;
+    snd_seq_client_info_alloca(&client_info);
+    snd_seq_get_client_info(_seq, client_info);
+    std::string client_name = snd_seq_client_info_get_name(client_info);
+    return client_name;
+}
+
+
+int ALSABackend::get_client_id()
+{
+    snd_seq_client_info_t *client_info;
+    snd_seq_client_info_alloca(&client_info);
+    snd_seq_get_client_info(_seq, client_info);
+    int client_id = snd_seq_client_info_get_client(client_info);
+    return client_id;
+}
+
+
 void ALSABackend::connect_ports_impl(
         PortConnectionMap const & port_connections,
         PortIdVector const & port_ids,

--- a/src/backend/alsa.hh
+++ b/src/backend/alsa.hh
@@ -57,6 +57,10 @@ class ALSABackend
     virtual void connect_ports(PortConnectionMap const & in_port_connections,
                                PortConnectionMap const & out_port_connections);
 
+    virtual std::string get_actual_client_name();
+
+    virtual int get_client_id();
+
   private:
     /**
      * Name and id of an ALSA port, including its client name/id.

--- a/src/backend/base.hh
+++ b/src/backend/base.hh
@@ -78,6 +78,12 @@ class BackendBase
     virtual void connect_ports(PortConnectionMap const &,
                                PortConnectionMap const &) { }
 
+    virtual std::string get_actual_client_name() { }
+
+    virtual int get_client_id() { }
+
+    virtual std::string get_client_uuid() { }
+
     // start MIDI processing, run init function. depending on the backend,
     // cycle may be called once (and not return) or periodically.
     virtual void start(InitFunction init, CycleFunction cycle) = 0;

--- a/src/backend/jack.cc
+++ b/src/backend/jack.cc
@@ -89,6 +89,20 @@ void JACKBackend::connect_ports(
 }
 
 
+std::string JACKBackend::get_actual_client_name()
+{
+    std::string client_name = jack_get_client_name(_client);
+    return client_name;
+}
+
+
+std::string JACKBackend::get_client_uuid()
+{
+    std::string client_uuid = jack_get_uuid_for_client_name(_client, jack_get_client_name(_client));
+    return client_uuid;
+}
+
+
 void JACKBackend::connect_ports_impl(
         PortConnectionMap const & port_connections,
         std::vector<jack_port_t *> const & ports,

--- a/src/backend/jack.hh
+++ b/src/backend/jack.hh
@@ -45,6 +45,10 @@ class JACKBackend
     virtual void connect_ports(PortConnectionMap const & in_port_connections,
                                PortConnectionMap const & out_port_connections);
 
+    virtual std::string get_actual_client_name();
+
+    virtual std::string get_client_uuid();
+
   protected:
     // XXX this should be pure virtual.
     // it isn't, because the process thread is started from within the c'tor

--- a/src/engine.hh
+++ b/src/engine.hh
@@ -102,6 +102,12 @@ class Engine
 
     double time();
 
+    std::string get_client_name() const { return _backend->get_actual_client_name(); };
+
+    int get_client_id() const { return _backend->get_client_id(); };
+
+    std::string get_client_uuid() const { return _backend->get_client_uuid(); };
+
     PythonCaller & python_caller() const { return *_python_caller; }
 
   protected:

--- a/src/python_module.cc
+++ b/src/python_module.cc
@@ -203,6 +203,9 @@ BOOST_PYTHON_MODULE(_mididings)
         .def("process_event", &Engine::process_event)
         .def("output_event", &Engine::output_event)
         .def("time", &Engine::time)
+        .def("get_client_name", &Engine::get_client_name)
+        .def("get_client_id", &Engine::get_client_id)
+        .def("get_client_uuid", &Engine::get_client_uuid)
     ;
 
 


### PR DESCRIPTION
I added support for mididings.engine.get_client_name() which returns the unique name of the mididings
sequencer engine (useful for unique jack names) and mididings.engine.get_client_id() which returns the client port number (ALSA) or client UUID (JACK) which in turn is useful for ALSA non-unique nature.
This is obviously not very useful for mididings only scripts, but for programs which use it as a module.
I have to make an apology: I know very little about programming, and, most important, I know almost nothing about c++. The code added looks "clean" and it works (at least on my machine), but I might have done things in a unorthodox way...
