### PR TITLE
Fix harmonizer to work in python3

### DIFF
--- a/mididings/arguments.py
+++ b/mididings/arguments.py
@@ -13,7 +13,7 @@
 from mididings import misc
 
 import inspect
-import collections
+import collections.abc as collections
 import types
 import functools
 

--- a/mididings/extra/harmonizer.py
+++ b/mididings/extra/harmonizer.py
@@ -39,7 +39,7 @@ class _Harmonizer(object):
             l = len(scale)
             i = scale.index(x) + interval
 
-            hx = scale[i % l] + ((i / l) * 12)
+            hx = scale[i % l] + ((i // l) * 12)
 
             self.lookup[x] = hx - x
 

--- a/mididings/units/call.py
+++ b/mididings/units/call.py
@@ -28,7 +28,7 @@ else:
 import subprocess as _subprocess
 import types as _types
 import copy as _copy
-import collections as _collections
+import collections.abc as _collections
 import inspect as _inspect
 
 

--- a/mididings/units/call.py
+++ b/mididings/units/call.py
@@ -33,7 +33,7 @@ import inspect as _inspect
 
 
 class _CallBase(_Unit):
-    def __init__(self, function, async, cont):
+    def __init__(self, function, asynchronous, cont):
         def do_call(ev):
             # add additional properties that don't exist on the C++ side
             ev.__class__ = _event.MidiEvent
@@ -41,7 +41,7 @@ class _CallBase(_Unit):
             # call the function
             ret = function(ev)
 
-            if ret is None or async:
+            if ret is None or asynchronous:
                 return None
             elif isinstance(ret, _types.GeneratorType):
                 # function is a generator, build list
@@ -53,7 +53,7 @@ class _CallBase(_Unit):
                 ev._finalize()
             return ret
 
-        _Unit.__init__(self, _mididings.Call(do_call, async, cont))
+        _Unit.__init__(self, _mididings.Call(do_call, asynchronous, cont))
 
 
 class _CallThread(_CallBase):

--- a/mididings/units/printing.py
+++ b/mididings/units/printing.py
@@ -18,7 +18,7 @@ import mididings.constants as _constants
 import mididings.misc as _misc
 
 import sys as _sys
-import collections as _collections
+import collections.abc as _collections
 
 
 class _Print(_CallBase):

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ def my_customize_compiler(compiler):
     # immediately stop on error
     compiler.compiler_so.append('-Wfatal-errors')
     # some options to reduce the size of the binary
-    compiler.compiler_so.append('-fvisibility=hidden')
     compiler.compiler_so.append('-fvisibility-inlines-hidden')
     return retval
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
     from commands import getstatusoutput
 
 
-version = '2015'
+version = '2019'
 
 status, output = getstatusoutput('git rev-parse --short HEAD')
 if not status:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import os
 import platform
 import sys
-
 from distutils import sysconfig
 
 try:
@@ -147,9 +146,9 @@ sources = [
 
 include_dirs.append('src')
 
-boost_python_suffixes = ['-py%d%d' % sys.version_info[:2]]
-if sys.version_info[0] == 3:
-    boost_python_suffixes.append('3')
+boost_python_suffixes = ['%d%d' % sys.version_info[:2]]
+# if sys.version_info[0] == 3:
+#     boost_python_suffixes.append('3')
 libraries.append(boost_lib_name('boost_python', boost_python_suffixes))
 libraries.append(boost_lib_name('boost_thread'))
 


### PR DESCRIPTION
Harmonizer() included division which produces a float in python3.
Values were therefore not valid to be passed to Transpose().